### PR TITLE
Handle additional DNF transaction callback actions in DNF 3

### DIFF
--- a/python/dnfdaemon/server/__init__.py
+++ b/python/dnfdaemon/server/__init__.py
@@ -97,6 +97,19 @@ class TransactionProgress(dnf.callback.TransactionProgress):
                         dnf.callback.PKG_SCRIPTLET: 'scriptlet',
                         dnf.callback.TRANS_PREPARATION: 'preptrans',
                         dnf.callback.TRANS_POST: 'posttrans'}
+        try:
+            # https://bugzilla.redhat.com/show_bug.cgi?id=1630113
+            # from dnf 3.0 onwards these exist and show up in
+            # callbacks, but aren't in the API
+            self.actions.update({
+                dnf.transaction.PKG_DOWNGRADED: 'downgraded',
+                dnf.transaction.PKG_OBSOLETED: 'obsoleted',
+                dnf.transaction.PKG_REINSTALLED: 'reinstalled',
+                dnf.transaction.PKG_UPGRADED: 'updated'
+            })
+        except AttributeError:
+            # we're on older DNF...
+            pass
 
         super(dnf.callback.TransactionProgress, self).__init__()
         self.base = base


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1624652 and
https://bugzilla.redhat.com/show_bug.cgi?id=1630113 . It seems
that a change in DNF 3 causes transaction callbacks to use
actions that aren't included in the callback API definition or
docs. Because dnfdaemon/dnfdragora currently kinda assume they
know all *possible* callback actions, this winds up causing
dnfdragora to crash if it tries to handle a callback with one
of these unknown actions.

This commit adds the extra actions to the const <-> string dict
in dnfdaemon's TransactionProgress callback, so that in the dbus
RPMProgress message it sends out, the action will be a string,
as dnfdragora's handler for the message expects. A companion
commit for dnfdragora will add handling for the new string
values, and also make it not crash if an unexpected action shows
up.

Signed-off-by: Adam Williamson <awilliam@redhat.com>