### PR TITLE
check_lock: treat 'locked by other' differently to 'not locked'

### DIFF
--- a/daemon/dnfdaemon-session.py
+++ b/daemon/dnfdaemon-session.py
@@ -95,7 +95,7 @@ class DnfDaemon(dnfdaemon.server.DnfDaemonBase):
                          sender_keyword='sender')
     def Lock(self, sender=None):
         '''
-        Get the yum lock
+        Get the dnfdaemon lock
         :param sender:
         '''
         if not self._lock:
@@ -367,13 +367,15 @@ class DnfDaemon(dnfdaemon.server.DnfDaemonBase):
 
     def check_lock(self, sender):
         '''
-        Check that the current sender is owning the yum lock
+        Check that the current sender is owning the dnfdaemon lock
         :param sender:
         '''
         if self._lock == sender:
             return True
+        elif self._lock:
+            raise LockedError('dnfdaemon is locked by another application')
         else:
-            raise LockedError('dnf is locked by another application')
+            raise LockedError('dnfdaemon is not locked, but was expected to be')
 
 
 def main():

--- a/daemon/dnfdaemon-system.py
+++ b/daemon/dnfdaemon-system.py
@@ -104,7 +104,7 @@ class DnfDaemon(dnfdaemon.server.DnfDaemonBase):
                          sender_keyword='sender')
     def Lock(self, sender=None):
         """
-        Get the yum lock
+        Get the dnfdaemon lock
         :param sender:
         """
         self.check_permission_read(sender)
@@ -699,13 +699,15 @@ class DnfDaemon(dnfdaemon.server.DnfDaemonBase):
 
     def check_lock(self, sender):
         """
-        Check that the current sender is owning the dnf lock
+        Check that the current sender is owning the dnfdaemon lock
         :param sender:
         """
         if self._lock == sender:
             return True
+        elif self._lock:
+            raise LockedError('dnfdaemon is locked by another application')
         else:
-            raise LockedError('dnf is locked by another application')
+            raise LockedError('dnfdaemon is not locked, but was expected to be')
 
     def check_permission_write(self, sender):
         """ Check for senders permission to update system packages"""


### PR DESCRIPTION
check_lock currently claims the daemon is locked by another app
even if the problem is actually that it *isn't locked at all*.
We should distinguish these two cases.

Also, here and in a few other places we refer to this as either
a 'dnf lock' or a 'yum lock'. AFAICT it is not either of those
things, it is a lock that is internal to the daemon. You can
happily perform operations with dnf *directly* while this lock
is held. It's confusing to describe this as a 'dnf lock' when
that isn't what it is, so this changes the description to
'dnfdaemon lock' in a few places.

Signed-off-by: Adam Williamson <awilliam@redhat.com>