### PR TITLE
GetRepo crashes when invoked

### DIFF
--- a/python/dnfdaemon/server/__init__.py
+++ b/python/dnfdaemon/server/__init__.py
@@ -189,6 +189,8 @@ class DnfDaemonBase(dbus.service.Object, DownloadCallback):
         self._config_options = {}
         self._enabled_repos = []
 
+
+
     # this must be overloaded in the parent class
     def GPGImport(self, pkg_id, userid, hexkeyid, keyurl, timestamp):
         #print(pkg_id, userid, hexkeyid, keyurl, timestamp)
@@ -296,10 +298,55 @@ class DnfDaemonBase(dbus.service.Object, DownloadCallback):
 
         :param repo_id: repo id to get information from
         """
+        optionKeys = [
+          'bandwidth'            ,
+          'basecachedir'         ,
+          'baseurl'              ,
+          'cost'                 ,
+          'deltarpm'             ,
+          'deltarpm_percentage'  ,
+          'enabled'              ,
+          'enabled_metadata'     ,
+          'enablegroups'         ,
+          'exclude'              ,
+          'excludepkgs'          ,
+          'failovermethod'       ,
+          'fastestmirror'        ,
+          'gpgcheck'             ,
+          'gpgkey'               ,
+          'includepkgs'          ,
+          'ip_resolve'           ,
+          'max_parallel_downloads',
+          'mediaid'              ,
+          'metadata_expire'      ,
+          'metalink'             ,
+          'minrate'              ,
+          'mirrorlist'           ,
+          'name'                 ,
+          'password'             ,
+          'priority'             ,
+          'protected_packages'   ,
+          'proxy'                ,
+          'proxy_password'       ,
+          'proxy_username'       ,
+          'repo_gpgcheck'        ,
+          'retries'              ,
+          'skip_if_unavailable'  ,
+          'sslcacert'            ,
+          'sslclientcert'        ,
+          'sslclientkey'         ,
+          'sslverify'            ,
+          'throttle'             ,
+          'timeout'              ,
+          'type'                 ,
+          'username'             ,
+        ]
         value = json.dumps(None)
         repo = self.base.repos.get(repo_id, None)  # get the repo object
         if repo:
-            repo_conf = dict([(c, getattr(repo, c)) for c in repo._option.keys()])
+            # VectorString is not JSON serializable let's convert to list
+            repo_conf = dict([(c, getattr(repo, c) if 'VectorString' not in str(type(getattr(repo, c))) else list(getattr(repo, c))) for c in optionKeys])
+
             enab = repo.enabled
             if not enab:
                 r = self._enabled_repos


### PR DESCRIPTION
Pdb) p self.backend.GetRepo(repo_id , sync=True)
*** gi.repository.GLib.GError: g-io-error-quark: GDBus.Error:org.freedesktop.DBus.Python.AttributeError: Traceback (most recent call last):
  File "/usr/lib64/python3.7/site-packages/dbus/service.py", line 707, in _message_cb
    retval = candidate_method(self, *args, **keywords)
  File "/usr/lib/python3.7/site-packages/dnfdaemon/server/__init__.py", line 68, in newFunc
    rc = func(*args, **kwargs)
  File "/usr/share/dnfdaemon/dnfdaemon-system", line 224, in GetRepo
    value = self.get_repo(repo_id)
  File "/usr/lib/python3.7/site-packages/dnfdaemon/server/__init__.py", line 302, in get_repo
    repo_conf = dict([(c, getattr(repo, c)) for c in repo._option.keys()])
  File "/usr/lib/python3.7/site-packages/dnf/conf/config.py", line 65, in __getattr__
    option = getattr(self._config, name)
  File "/usr/lib64/python3.7/site-packages/libdnf/conf.py", line 1647, in <lambda>
    __getattr__ = lambda self, name: _swig_getattr(self, ConfigRepo, name)
  File "/usr/lib64/python3.7/site-packages/libdnf/conf.py", line 80, in _swig_getattr
    raise AttributeError("'%s' object has no attribute '%s'" % (class_type.__name__, name))
AttributeError: 'ConfigRepo' object has no attribute '_option'
