### PR TITLE
Fix 'dnf.history' has no attribute 'open_history'

### DIFF
--- a/python/dnfdaemon/server/__init__.py
+++ b/python/dnfdaemon/server/__init__.py
@@ -699,12 +699,10 @@ class DnfDaemonBase(dbus.service.Object, DownloadCallback):
             result = (False, ['Transaction not found'])
         else:
             old = old[0]
-            history = dnf.history.open_history(self.base.history)
+            mobj = dnf.db.history.MergedTransactionWrapper(old)
             try:
                 # FIXME: Base.history_undo_operations is not public api
-                #print(len(history.transaction_nevra_ops(old.tid)))
-                self.base._history_undo_operations(
-                     history.transaction_nevra_ops(old.tid), old.tid)
+                self.base._history_undo_operations(mobj, old.tid)
                 #print(self.get_transaction())
             except dnf.exceptions.PackagesNotInstalledError as err:
                 result = (False, ['An operation cannot be undone : %s' %


### PR DESCRIPTION
'open_history' has been deprecated since dnf 3.0.1 in PR 1043

[dnf commit: [swdb] Replace dnf.history and dnf.transaction modules.](https://github.com/rpm-software-management/dnf/commit/8198019c0488258be589af3935a1bc579ab29786#diff-7fba0092ec8c6ecc5a8eb7458d9b713909a0fc27b5468f2e4d580ab333793564L626-R646)