### PR TITLE
Reduce duration of loading cache

### DIFF
--- a/daemon/dnfdaemon-system.py
+++ b/daemon/dnfdaemon-system.py
@@ -235,7 +235,10 @@ class DnfDaemon(dnfdaemon.server.DnfDaemonBase):
         :param sender:
         """
         self.working_start(sender, write=False)
-        value = self.get_packages(pkg_filter, fields)
+        if fields ==  ['summary', 'size', 'group']:
+            value = self.get_packages_ndsg(pkg_filter)
+        else:
+            value = self.get_packages(pkg_filter, fields)
         return self.working_ended(value)
 
     @Logger

--- a/python/dnfdaemon/server/__init__.py
+++ b/python/dnfdaemon/server/__init__.py
@@ -387,6 +387,20 @@ class DnfDaemonBase(dbus.service.Object, DownloadCallback):
             value = [self._get_po_list(po, attrs) for po in pkgs]
         return json.dumps(value)
 
+    @Logger
+    def get_packages_ndsg(self, pkg_filter):
+        """Get packages and attribute values based on a filter.
+
+        :param pkg_filter: pkg pkg_filter string ('installed','updates' etc)
+        :param attrs: list of attributes to get.
+        """
+        value = []
+        if pkg_filter in ['installed', 'available', 'updates', 'obsoletes',
+                          'recent', 'extras', 'updates_all']:
+            pkgs = getattr(self.base.packages, pkg_filter)
+            value = [[self._get_id(po), po.summary, po.size, po.group] for po in pkgs]
+        return json.dumps(value)
+
     def get_attribute(self, id, attr):
         """Get package attribute.
 

--- a/python/dnfdaemon/server/__init__.py
+++ b/python/dnfdaemon/server/__init__.py
@@ -1061,11 +1061,10 @@ class DnfDaemonBase(dbus.service.Object, DownloadCallback):
 
     def _get_id(self, pkg):
         """Get a package id from a given package."""
-        values = [pkg.name, str(pkg.epoch), pkg.version, pkg.release, pkg.arch]
         if callable(pkg.ui_from_repo):
-            values.append(pkg.ui_from_repo())
+            values = [pkg.name, str(pkg.epoch), pkg.version, pkg.release, pkg.arch, pkg.ui_from_repo()]
         else:
-            values.append(pkg.ui_from_repo)
+        values = [pkg.name, str(pkg.epoch), pkg.version, pkg.release, pkg.arch, pkg.ui_from_repo]
         return ",".join(values)
 
     def _get_action(self, po):


### PR DESCRIPTION
In my tests with profiling, using yappi and valgrind, I see that in get_packages from server/__init__.py, 35% of the time is consumed in _get_po_list which is called for each package (27 000 in my case). 
The first improvement is in _get_id function. Initially, this function prepares a set, then appends the last value according to a test. Now, the whole is declared according to the result of the test.
The second improvement is a conditional test on the fields to return from the GetPackages call. If the set of fields is  ['summary', 'size', 'group'], I call a specific function get_packages_ndsg which return directly the attributes without testing them.

Now the improvement is about 20% of the the duration of loading cache.