### PR TITLE
Fix python 3.10 detection in makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ORG_RO_NAME = org.baseurl.DnfSession
 SUBDIRS = python
 VERSION=$(shell awk '/Version:/ { print $$2 }' ${PKGNAME}.spec)
 TESTLIBS=python/:test/
-PYVER3 := $(shell python3 -c 'import sys; print("%.3s" %(sys.version))')
+PYVER3 := $(shell python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
 GITDATE=git$(shell date +%Y%m%d)
 VER_REGEX=\(^Version:\s*[0-9]*\.[0-9]*\.\)\(.*\)
 BUMPED_MINOR=${shell VN=`cat ${APPNAME}.spec | grep Version| sed  's/${VER_REGEX}/\2/'`; echo $$(($$VN + 1))}

--- a/python/dnfdaemon/Makefile
+++ b/python/dnfdaemon/Makefile
@@ -1,7 +1,7 @@
 PYTHON3=python3
 PACKAGE = dnfdaemon
 PYFILES = $(wildcard *.py)
-PYVER3 := $(shell $(PYTHON3) -c 'import sys; print("%.3s" %(sys.version))')
+PYVER3 := $(shell $(PYTHON3) -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
 PYSYSDIR3 := $(shell $(PYTHON3) -c 'import sys; print(sys.prefix)')
 PYLIBDIR3 = $(PYSYSDIR3)/lib/python$(PYVER3)
 PKGDIR3 = $(PYLIBDIR3)/site-packages/$(PACKAGE)

--- a/python/dnfdaemon/client/Makefile
+++ b/python/dnfdaemon/client/Makefile
@@ -1,7 +1,7 @@
 PYTHON3=python3
 PACKAGE = dnfdaemon/client
 PYFILES = $(wildcard *.py)
-PYVER3 := $(shell $(PYTHON3) -c 'import sys; print("%.3s" %(sys.version))')
+PYVER3 := $(shell $(PYTHON3) -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
 PYSYSDIR3 := $(shell $(PYTHON3) -c 'import sys; print(sys.prefix)')
 PYLIBDIR3 = $(PYSYSDIR3)/lib/python$(PYVER3)
 PKGDIR3 = $(PYLIBDIR3)/site-packages/$(PACKAGE)

--- a/python/dnfdaemon/server/Makefile
+++ b/python/dnfdaemon/server/Makefile
@@ -1,7 +1,7 @@
 PYTHON3=python3
 PACKAGE = dnfdaemon/server
 PYFILES = $(wildcard *.py)
-PYVER3 := $(shell $(PYTHON3) -c 'import sys; print("%.3s" %(sys.version))')
+PYVER3 := $(shell $(PYTHON3) -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
 PYSYSDIR3 := $(shell $(PYTHON3) -c 'import sys; print(sys.prefix)')
 PYLIBDIR3 = $(PYSYSDIR3)/lib/python$(PYVER3)
 PKGDIR3 = $(PYLIBDIR3)/site-packages/$(PACKAGE)


### PR DESCRIPTION
When built using python 3.10, the Makefiles were setting PYVER3 to 3.1.  I don't know if the rest of the code is python 3.10 compatible, but this still needs to be fixed.