### PR TITLE
Fix GetRepo breaking because 'failovermethod' repo property has been removed in latest dnf & friends

### DIFF
--- a/python/dnfdaemon/server/__init__.py
+++ b/python/dnfdaemon/server/__init__.py
@@ -313,7 +313,6 @@ class DnfDaemonBase(dbus.service.Object, DownloadCallback):
           'enablegroups'         ,
           'exclude'              ,
           'excludepkgs'          ,
-          'failovermethod'       ,
           'fastestmirror'        ,
           'gpgcheck'             ,
           'gpgkey'               ,

--- a/python/dnfdaemon/server/__init__.py
+++ b/python/dnfdaemon/server/__init__.py
@@ -346,8 +346,14 @@ class DnfDaemonBase(dbus.service.Object, DownloadCallback):
         value = json.dumps(None)
         repo = self.base.repos.get(repo_id, None)  # get the repo object
         if repo:
-            # VectorString is not JSON serializable let's convert to list
-            repo_conf = dict([(c, getattr(repo, c) if 'VectorString' not in str(type(getattr(repo, c))) else list(getattr(repo, c))) for c in optionKeys])
+            repo_conf = {}
+            for c in optionKeys:
+                if hasattr(repo,c):
+                    value = getattr(repo, c)
+                    # VectorString is not JSON serializable let's convert to list
+                    if 'VectorString' in str(type(value)):
+                        value = list(value)
+                    repo_conf[c] = value
 
             enab = repo.enabled
             if not enab:


### PR DESCRIPTION
Removed fetching the failovermethod property and make the code more error prone, for missing properties in the future.

https://github.com/timlau/yumex-dnf/issues/166


